### PR TITLE
ISSUE#4: `this.props.onBack.apply(this, [navigator.getCurrentRoutes().length])…

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ export function createNavigatorRouter(onBack = null, style = {}) {
 
       const { navigator } = this.refs;
       if (navigator) {
-        return this.props.onBack.apply(this, [navigator.getCurrentRoutes().length]);
+        return onBack.apply(this, [navigator.getCurrentRoutes().length]);
       }
 
       return false;


### PR DESCRIPTION
…`, here `onBack` is not part of `NavigatorRouter` therefore it was throwing error as undefined. Since `onBack` is already part of parent scope component/function therefore changed as `onBack.apply(this, [navigator.getCurrentRoutes().length])`